### PR TITLE
 Resovle the issuse of cannot auto running runc in host

### DIFF
--- a/Cases/Specstest/root_readonly_true/source/Specstest-root_readonly_true-runc.json
+++ b/Cases/Specstest/root_readonly_true/source/Specstest-root_readonly_true-runc.json
@@ -1,0 +1,69 @@
+{
+        "Name": "Specstest-root_readonly_true-runc",
+        "Summary": "test based opencontainers/specs",
+        "Owner": "linzhinan@huawei.com",
+        "Description": "Test runc when spec root:readonly == true",
+        "Group": "Specstest/root_readonly_true/",
+        "License": "Apache 2.0",
+        "Explains" "Test runc when spec root:readonly == true"
+        "Source": [
+                    "./source/config.json",
+	       "./source/root_readonly_true_host.go",
+                    "./source/root_readonly_true_guest.go"
+        ],
+        "Requires": [
+            {
+                
+	       "Class":"operationOS", 
+	        "Type": "os",
+	        "Distribution": "Ubuntu14.04",
+	        "Resource": {
+	            "CPU": 4,
+	            "Memory": "16GB",
+	            "Disk": "200G"
+	        }
+                
+            }
+            {
+                
+                "Class": "specstest",
+                "Type": "container",
+                "Version": "runc V0.2",
+                "Files": [
+		   "./source/Dockerfile"
+		]
+                
+            }
+        ],
+        "Deploys": [
+            {
+                "Object": "hostA",
+                "Class": "OperationOS",
+                "Cmd": "cd ./source/",
+                "Cmd": "go build root_readonly_true_host.go",
+                "Cmd": "./root_readonly_true_host",
+                "Containers": [
+                    {
+                        "Object": "specs",
+                        "Class": "specstest"
+                    }
+                ]
+            }         
+        ],
+          "Run": [
+            {
+                "Object": "hostA",
+                "Class": "OperationOS",
+                "Cmd": "cd ./source/",
+                "Cmd": "runc"
+            }
+        ],
+        "Collect": [
+            {
+                "Object": "hostA",
+                "Files": ["/tmp/testtool/readonly_true_out.txt"]
+            }
+        ]
+    
+}
+

--- a/Cases/Specstest/root_readonly_true/source/config.json
+++ b/Cases/Specstest/root_readonly_true/source/config.json
@@ -12,7 +12,7 @@
       "additionalGids": null
     },
     "args": [
-      "bash"
+      "./root_readonly_true_guest"
     ],
     "env": [
       "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
@@ -21,10 +21,10 @@
     "cwd": "/testtool"
   },
   "root": {
-    "path": "rootfs_rootconfig",
-    "readonly": false
+    "path": "./../../source/rootfs_rootconfig",
+    "readonly": true
   },
-  "hostname": "shell",
+  "hostname": "bash",
   "mounts": [
     {
       "type": "bind",
@@ -65,7 +65,7 @@
     {
       "type": "sysfs",
       "source": "sysfs",
-      "destination": "/sys", 
+      "destination": "/sys",
       "options": "nosuid,noexec,nodev"
     },
     {

--- a/Cases/Specstest/root_readonly_true/source/root_readonly_true_guest.go
+++ b/Cases/Specstest/root_readonly_true/source/root_readonly_true_guest.go
@@ -16,8 +16,9 @@ package main
 
 import (
 	//"bytes"
-	"fmt"
+	//"fmt"
 	"log"
+	"os"
 	"os/exec"
 	"strings"
 )
@@ -33,14 +34,22 @@ func testRootReadonlyTrue() {
 	}
 
 	outString := string(outBytes)
-	fmt.Println(outString)
-
-	if strings.Contains(outString, "ro") {
-		fmt.Println("[YES]        Linuxspec.Spec.Root.Readonly == ture   passed")
+	var resultString string
+	if strings.Contains(outString, "(ro,") {
+		resultString = "[YES]        Linuxspec.Spec.Root.Readonly == ture   passed"
 	} else {
-		log.Fatalf("[NO]        Linuxspec.Spec.Root.Readonly == ture   failed")
+		resultString = "[NO]        Linuxspec.Spec.Root.Readonly == ture   failed"
 	}
 
+	foutfile := "/testtool/readonly_true_out.txt"
+	fout, err := os.Create(foutfile)
+	defer fout.Close()
+
+	if err != nil {
+		log.Fatal(err)
+	} else {
+		fout.WriteString(resultString)
+	}
 }
 
 func main() {

--- a/Cases/Specstest/root_readonly_true/source/root_readonly_true_host.go
+++ b/Cases/Specstest/root_readonly_true/source/root_readonly_true_host.go
@@ -24,7 +24,7 @@ import (
 
 func testRootReadonlyTrue() {
 
-	cmd := exec.Command("/bin/sh", "-c", " sudo -u zenlin go build root_readonly_true_guest.go")
+	cmd := exec.Command("/bin/sh", "-c", "go build root_readonly_true_guest.go")
 	_, err := cmd.Output()
 	if err != nil {
 		log.Fatalf("Specstest root readonly test: build guest programme error, %v", err)

--- a/Cases/Specstest/root_readonly_true/source/root_readonly_true_host.go
+++ b/Cases/Specstest/root_readonly_true/source/root_readonly_true_host.go
@@ -23,13 +23,35 @@ import (
 )
 
 func testRootReadonlyTrue() {
-	var hostpasswd string
-	hostpasswd = "565513"
 
-	cmd := exec.Command("/bin/sh", "-c", "echo "+hostpasswd+" | sudo mkdir -p /tmp/testtool")
+	cmd := exec.Command("/bin/sh", "-c", " sudo -u zenlin go build root_readonly_true_guest.go")
 	_, err := cmd.Output()
 	if err != nil {
-		log.Fatalf("Specstest root readonly test: pull image error, %v", err)
+		log.Fatalf("Specstest root readonly test: build guest programme error, %v", err)
+	}
+
+	cmd = exec.Command("/bin/sh", "-c", "mkdir -p /tmp/testtool")
+	_, err = cmd.Output()
+	if err != nil {
+		log.Fatalf("Specstest root readonly test: mkdir testtool dir error, %v", err)
+	}
+
+	cmd = exec.Command("/bin/sh", "-c", "mv root_readonly_true_guest /tmp/testtool/")
+	_, err = cmd.Output()
+	if err != nil {
+		log.Fatalf("Specstest root readonly test: mv guest programme error, %v", err)
+	}
+
+	cmd = exec.Command("/bin/sh", "-c", "touch  /tmp/testtool/readonly_true_out.txt")
+	_, err = cmd.Output()
+	if err != nil {
+		log.Fatalf("Specstest root readonly test: touch readonly_true_out.txt err, %v", err)
+	}
+
+	cmd = exec.Command("/bin/sh", "-c", "chown root:root  /tmp/testtool/readonly_true_out.txt")
+	_, err = cmd.Output()
+	if err != nil {
+		log.Fatalf("Specstest root readonly test: change to root power err, %v", err)
 	}
 
 	cmd = exec.Command("/bin/sh", "-c", "docker pull ubuntu:14.04")
@@ -44,13 +66,13 @@ func testRootReadonlyTrue() {
 		log.Fatalf("Specstest root readonly test: export image error, %v", err)
 	}
 
-	cmd = exec.Command("/bin/sh", "-c", "mkdir -p rootfs_rootconfig")
+	cmd = exec.Command("/bin/sh", "-c", "mkdir -p ./../../source/rootfs_rootconfig")
 	_, err = cmd.Output()
 	if err != nil {
 		log.Fatalf("Specstest root readonly test: create rootfs dir error, %v", err)
 	}
 
-	cmd = exec.Command("/bin/sh", "-c", "echo "+hostpasswd+" | sudo tar -C rootfs_rootconfig -xf ubuntu.tar")
+	cmd = exec.Command("/bin/sh", "-c", "tar -C ./../../source/rootfs_rootconfig -xf ubuntu.tar")
 	_, err = cmd.Output()
 	if err != nil {
 		log.Fatalf("Specstest root readonly test: create rootfs content error, %v", err)
@@ -65,7 +87,7 @@ func testRootReadonlyTrue() {
 		log.Fatalf("Specstestroot readonly test: readconfig error, %v", err)
 	}
 
-	linuxspec.Spec.Root.Path = "rootfs_rootconfig"
+	linuxspec.Spec.Root.Path = "./../../source/rootfs_rootconfig"
 	linuxspec.Spec.Root.Readonly = true
 	err = configconvert.LinuxSpecToConfig(filePath, linuxspec)
 	//err = wirteConfig(filePath, linuxspec)
@@ -73,6 +95,13 @@ func testRootReadonlyTrue() {
 		log.Fatalf("Specstest root readonly test: writeconfig error, %v", err)
 	}
 	fmt.Println("Host enviroment for runc is already!")
+
+	/*
+		cmd = exec.Command("/bin/bash", "-c", "runc")
+		_, err = cmd.Output()
+		if err != nil {
+			log.Fatalf("Specstest root readonly test: start runc and test error, %v", err)
+		}*/
 }
 
 func main() {


### PR DESCRIPTION
   Resovle the issuse of cannot running runc in host:
    make guest programme to auto run according to config the process item in config.json;
    auto write output message to the host env.
    Add json file for testcase root_readonly_true.
    Correct name of the guest programme.
    
    The case can run by the newest test engine.